### PR TITLE
Fix truncate histories

### DIFF
--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -497,7 +497,12 @@ function! s:get_histories() abort
     return []
   endif
 
-  return map(readfile(history_path)[-g:deol#shell_history_max :],
+  let l:histories = readfile(history_path)
+  if g:deol#shell_history_max > 0 &&
+      \ len(l:histories) > g:deol#shell_history_max
+      let l:histories = l:histories[-g:deol#shell_history_max :]
+  endif
+  return map(l:histories,
         \ 'substitute(v:val, "^\\%(\\d\\+/\\)\\+[:[:digit:]; ]\\+\\|' .
         \ '^[:[:digit:]; ]\\+", "", "g")')
 endfunction


### PR DESCRIPTION
If the number of lines in the file `g:deol#shell_history_path` is less than `g:deol#shell_history_max`, an empty list is returned.

Modified like [vimshell souce code](https://github.com/Shougo/vimshell.vim/blob/03bf7673a5098918a533000d67dca97546695237/autoload/vimshell/history.vim#L61-L65) 