### PR TITLE
Trivial doc fix

### DIFF
--- a/doc/deol.txt
+++ b/doc/deol.txt
@@ -45,8 +45,8 @@ COMMANDS 						*deol-commands*
 :DeolEdit						*:DeolEdit*
 	Open deol edit buffer.
 	You can edit and execute the deol command line in the buffer.
-	The buffer filetype is "zsh" and you can use Vim auto completion
-	feature.
+	The buffer filetype is "zsh" if you use bash or zsh, and you can use
+	Vim auto completion feature.
 	Note: deoplete + deoplete-zsh is recommended.
 	https://github.com/Shougo/deoplete.nvim
 	https://github.com/zchee/deoplete-zsh


### PR DESCRIPTION
* According to autoload/deol.vim, not all of them fallback to zsh filetype.

```vim
  let default_filetype = {
        \ 'ash': 'sh',
        \ 'bash': 'zsh',
        \ 'fish': 'fish',
        \ 'ksh': 'sh',
        \ 'sh': 'sh',
        \ 'zsh': 'zsh',
        \ 'xonsh': 'python',
        \ }
```