### PR TITLE
Backspace closes the deol-edit window

### DIFF
--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -468,8 +468,9 @@ function! s:send_editor() abort
 endfunction
 
 function! s:deol_backspace() abort
-  if col('.') == 1 && t:deol.options.toggle
+  if getline('.') ==# '' && t:deol.options.toggle
     call deol#quit()
+  elseif col('.') == 1
   else
     normal! x
   endif

--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -401,8 +401,8 @@ function! s:deol.init_edit_buffer() abort
         \ :<C-u>call deol#quit()<CR>
   inoremap <buffer><silent> <Plug>(deol_quit)
         \ <ESC>:call deol#quit()<CR>
-  inoremap <buffer><expr><silent> <Plug>(deol_backspace)
-        \ col('.') == 1 ? "" : "<BS>"
+  inoremap <buffer><silent> <Plug>(deol_backspace)
+        \ <C-o>:call <SID>deol_backspace()<CR>
   nnoremap <buffer><expr><silent> <Plug>(deol_ctrl_c)
         \ deol#send("\<C-c>")
   inoremap <buffer><expr><silent> <Plug>(deol_ctrl_c)
@@ -464,6 +464,14 @@ function! s:send_editor() abort
     if isdirectory(directory)
       noautocmd call s:cd(directory)
     endif
+  endif
+endfunction
+
+function! s:deol_backspace() abort
+  if col('.') == 1 && t:deol.options.toggle
+    call deol#quit()
+  else
+    normal! x
   endif
 endfunction
 


### PR DESCRIPTION
Not sure if you like, but how does this look? (That's actually how I used vimshell too.)

* BEFORE:
    * `<BS>` at deol-edit removes a character, but does not remove beyond the current line.
* AFTER:
    * `<BS>` at deol-edit removes a character, but does not remove beyond the current line.
    * Only if you start deol-edit with `-toggle`, it closes the deol/deol-edit buffers when you are at the top of the line.