### PR TITLE
Add -farleft and -farright options

### DIFF
--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -539,6 +539,14 @@ function! s:split(options) abort
   elseif a:options.split ==# 'vertical'
     vsplit
     execute 'vertical resize' str2nr(a:options.winwidth)
+  elseif a:options.split ==# 'farleft'
+    vsplit
+    wincmd H
+    execute 'vertical resize' str2nr(a:options.winwidth)
+  elseif a:options.split ==# 'farright'
+    vsplit
+    wincmd L
+    execute 'vertical resize' str2nr(a:options.winwidth)
   else
     split
     execute 'resize' str2nr(a:options.winheight)

--- a/doc/deol.txt
+++ b/doc/deol.txt
@@ -100,6 +100,8 @@ OPTIONS							*deol-options*
 		"": No split
 		"floating": Use neovim floating window feature
 		"vertical": Split buffer vertically
+		"farleft": Split buffer far left, like |CTRL-W_H|
+		"farright": Split buffer far right, like |CTRL-W_H|
 		otherwise: Split buffer horizontally
 
 		Default: ""


### PR DESCRIPTION
This allows using Vim like this:

* Before :Deol https://gyazo.com/f71f0787b1ef40ca62b6262e6748126c
* After :Deol -split=farleft -toggle https://gyazo.com/ae4d5328b984af2bdb0ee9f3fb89cf68
* After :Deol -split=farleft -toggle again https://gyazo.com/a2c8eb7e8ede6ebb3278226480012dda

Hypothesis is that you need big enough space for the deol terminal to see the command output. Not always -split=horizontal or -split=vertical can provide a big enough space all the time.