### PR TITLE
$EDITOR and $GIT_EDITOR revamps

### DIFF
--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -219,10 +219,10 @@ function! deol#_new(cwd, options) abort
   let editor_command = ''
   if executable('nvr')
     let editor_command = 'nvr --remote-tab-wait-silent'
-  elseif executable('gvim')
-    let editor_command =
-          \ printf('gvim %s --remote-tab-wait-silent',
-          \   (v:servername ==# '' ? '' : ' --servername='.v:servername))
+  elseif v:progname ==# 'gvim' && executable('gvim')
+    let editor_command = 'gvim --nofork'
+  else
+    let editor_command = v:progpath
   endif
   if editor_command !=# ''
     let $EDITOR = editor_command

--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -220,7 +220,9 @@ function! deol#_new(cwd, options) abort
   if executable('nvr')
     let editor_command = 'nvr --remote-tab-wait-silent'
   elseif v:progname ==# 'gvim' && executable('gvim')
-    let editor_command = 'gvim --nofork'
+    let editor_command =
+          \ printf('gvim %s --remote-tab-wait-silent',
+          \   (v:servername ==# '' ? '' : ' --servername='.v:servername))
   else
     let editor_command = v:progpath
   endif

--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -217,7 +217,7 @@ function! deol#_new(cwd, options) abort
 
   " Set $EDITOR.
   let editor_command = ''
-  if v:progname ==# 'nvr' && executable('nvr')
+  if v:progname ==# 'nvim' && executable('nvr')
     let editor_command = 'nvr --remote-tab-wait-silent'
   elseif v:progname ==# 'gvim' && executable('gvim')
     let editor_command =

--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -217,7 +217,7 @@ function! deol#_new(cwd, options) abort
 
   " Set $EDITOR.
   let editor_command = ''
-  if executable('nvr')
+  if v:progname ==# 'nvr' && executable('nvr')
     let editor_command = 'nvr --remote-tab-wait-silent'
   elseif v:progname ==# 'gvim' && executable('gvim')
     let editor_command =


### PR DESCRIPTION
* `gvim --remote-tab-wait-silent` can't tell when commit message edit finished, even with `--nofork` option.
    * Let's just use `gvim --nofork` to spin up another gvim instance
* Use v:progname and v:progpath to be more robust
* Thanks @Shougo and @thinca for pair-programming!