### PR TITLE
Suggest deoplete-zsh for zsh users

### DIFF
--- a/doc/deol.txt
+++ b/doc/deol.txt
@@ -53,7 +53,8 @@ COMMANDS 						*deol-commands*
 	"cd {path}"	|:lcd| to {path} if |deol-options-auto-cd| is enabled
 	"vim {path}"	Quit deol buffer and |:edit| {path}
 
-	Note: deoplete + deoplete-zsh is recommended for auto completion.
+	Note: deoplete + deoplete-zsh is recommended for auto completion,
+	if you use Deol with -command zsh or if you set 'shell' to zsh.
 	https://github.com/Shougo/deoplete.nvim
 	https://github.com/zchee/deoplete-zsh
 


### PR DESCRIPTION
Looks like deol.nvim has changed the filetype for deol-edit buffer from zsh to bash by default, so the doc turned deprecated. It seems to be applicable only for people who specifically set to use zsh instead of bash.