### PR TITLE
Add -editwinheight option to :Deol -edit

### DIFF
--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -414,7 +414,7 @@ function! s:deol.init_edit_buffer() abort
   setlocal norelativenumber
   setlocal noswapfile
 
-  resize 1
+  execute 'resize' get(self.options, 'editwinheight', 1)
 
   " Set filetype
   let command = fnamemodify(self.command, ':t:r')
@@ -804,6 +804,7 @@ function! s:user_options() abort
         \ 'winheight': 15,
         \ 'winrow': &lines / 3,
         \ 'winwidth': 80,
+        \ 'editwinheight': 1,
         \ }
 endfunction
 

--- a/autoload/deol.vim
+++ b/autoload/deol.vim
@@ -414,7 +414,7 @@ function! s:deol.init_edit_buffer() abort
   setlocal norelativenumber
   setlocal noswapfile
 
-  execute 'resize' get(self.options, 'editwinheight', 1)
+  execute 'resize' self.options.editwinheight
 
   " Set filetype
   let command = fnamemodify(self.command, ':t:r')

--- a/doc/deol.txt
+++ b/doc/deol.txt
@@ -139,6 +139,13 @@ OPTIONS							*deol-options*
 
 		Default: 80
 
+						*deol-option-editwineight*
+-editwinheight={window-height}
+		Set the height of the deol edit window.
+
+		Default: 1
+
+
 ------------------------------------------------------------------------------
 VARIABLES 						*deol-variables*
 


### PR DESCRIPTION
* Problem: By default the height is 1 which is very hard to use
    * I've been manually extended https://github.com/ujihisa/config/blob/8623ba4017d4bc3d817c8cb311f59817978a03bb/_vimrc#L2641
    * e.g. I can't `:new` from deol-edit, due to no room error
* Solution: Keep the default behaviour as is, and add an option to keep it larger